### PR TITLE
Properly disable small types by default with RADV

### DIFF
--- a/parallel-rdp/rdp_renderer.cpp
+++ b/parallel-rdp/rdp_renderer.cpp
@@ -161,7 +161,7 @@ bool Renderer::init_caps()
 			LOGW("Current proprietary AMD driver is known to be buggy with 8/16-bit integer arithmetic, disabling support for time being.\n");
 			allow_small_types = false;
 		}
-		else if (features.driver_properties.driverID == VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR)
+		else if (features.driver_properties.driverID == VK_DRIVER_ID_MESA_RADV)
 		{
 			LOGW("Current RADV driver is known to be slightly faster without 8/16-bit integer arithmetic.\n");
 			allow_small_types = false;


### PR DESCRIPTION
It looks like this meant to use `VK_DRIVER_ID_MESA_RADV`

I don't think they will be disabled with AMDVLK. I don't know if they are supposed to be or not