### PR TITLE
Span overflow robustness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ add_rdp_test(fill-16)
 add_rdp_test(fill-16-interlace)
 add_rdp_test(fill-16-ia)
 add_rdp_test(fill-32)
+add_rdp_test(fill-ym-out-of-range)
 
 add_rdp_test(copy-4bpp-fb16-tlut)
 add_rdp_test(copy-8bpp-fb16-tlut)

--- a/parallel-rdp/rdp_renderer.cpp
+++ b/parallel-rdp/rdp_renderer.cpp
@@ -937,23 +937,34 @@ DerivedSetup Renderer::build_derived_attributes(const AttributeSetup &attr) cons
 
 static constexpr unsigned SUBPIXELS_Y = 4;
 
-static std::pair<int, int> interpolate_x(const TriangleSetup &setup, int y, bool flip, int scaling)
+static int32_t clamp_int32(int64_t v)
 {
-	int yh_interpolation_base = setup.yh & ~(SUBPIXELS_Y - 1);
-	int ym_interpolation_base = setup.ym;
+	if (v < std::numeric_limits<int32_t>::min())
+		return std::numeric_limits<int32_t>::min();
+	else if (v > std::numeric_limits<int32_t>::max())
+		return std::numeric_limits<int32_t>::max();
+	else
+		return int32_t(v);
+}
+
+static std::pair<int32_t, int32_t> interpolate_x(const TriangleSetup &setup, int y, bool flip, int scaling)
+{
+	// Interpolate in 64-bit so we are guaranteed to catch any overflow scenario.
+	int64_t yh_interpolation_base = setup.yh & ~(SUBPIXELS_Y - 1);
+	int64_t ym_interpolation_base = setup.ym;
 	yh_interpolation_base *= scaling;
 	ym_interpolation_base *= scaling;
 
-	int xh = scaling * setup.xh + (y - yh_interpolation_base) * setup.dxhdy;
-	int xm = scaling * setup.xm + (y - yh_interpolation_base) * setup.dxmdy;
-	int xl = scaling * setup.xl + (y - ym_interpolation_base) * setup.dxldy;
+	int64_t xh = scaling * setup.xh + int64_t(y - yh_interpolation_base) * setup.dxhdy;
+	int64_t xm = scaling * setup.xm + int64_t(y - yh_interpolation_base) * setup.dxmdy;
+	int64_t xl = scaling * setup.xl + int64_t(y - ym_interpolation_base) * setup.dxldy;
 	if (y < scaling * setup.ym)
 		xl = xm;
 
-	int xh_shifted = xh >> 15;
-	int xl_shifted = xl >> 15;
+	int64_t xh_shifted = xh >> 15;
+	int64_t xl_shifted = xl >> 15;
 
-	int xleft, xright;
+	int64_t xleft, xright;
 	if (flip)
 	{
 		xleft = xh_shifted;
@@ -965,7 +976,7 @@ static std::pair<int, int> interpolate_x(const TriangleSetup &setup, int y, bool
 		xright = xh_shifted;
 	}
 
-	return { xleft, xright };
+	return { clamp_int32(xleft), clamp_int32(xright) };
 }
 
 unsigned Renderer::compute_conservative_max_num_tiles(const TriangleSetup &setup) const
@@ -1000,8 +1011,27 @@ unsigned Renderer::compute_conservative_max_num_tiles(const TriangleSetup &setup
 		mid1 = interpolate_x(setup, ym - 1, flip, scaling);
 	}
 
-	int start_x = std::min(std::min(upper.first, lower.first), std::min(mid.first, mid1.first));
-	int end_x = std::max(std::max(upper.second, lower.second), std::max(mid.second, mid1.second));
+	// Robustness, check if we overflow the X rasterizer precision.
+	// After shifting down, we should have 12 bits signed.
+	// If we detect any overflow here we need to assume X range is scissor rect.
+	// This really should never happen, but it's possible to write tests that intentionally trigger weird
+	// overflow behavior that needs to be specially handled.
+	// There might be freak scenarios where we cannot detect overflow since we're only sampling at 4 scanlines
+	// and we have ~32 overflows happening at once,
+	// So we need to interpolate in 64-bit to make this work.
+
+	auto start_x = std::min(std::min(upper.first, lower.first), std::min(mid.first, mid1.first));
+	auto end_x = std::max(std::max(upper.second, lower.second), std::max(mid.second, mid1.second));
+
+	auto max_range_x = std::max(std::abs(start_x), std::abs(end_x));
+	// Effective X range is [-2048, 2047], but just make it [-2047, 2047] to match binning shader.
+	// If we interpolate X to something outside that range,
+	// we must assume the entire X range will be covered.
+	if (max_range_x > 2047 * scaling)
+	{
+		start_x = 0;
+		end_x = 0x7fffffff;
+	}
 
 	start_x = std::max(start_x, scaling * (int(stream.scissor_state.xlo) >> 2));
 	end_x = std::min(end_x, scaling * ((int(stream.scissor_state.xhi) + 3) >> 2) - 1);

--- a/parallel-rdp/rdp_renderer.hpp
+++ b/parallel-rdp/rdp_renderer.hpp
@@ -88,8 +88,9 @@ public:
 
 	bool init_renderer(const RendererOptions &options);
 
-	void draw_flat_primitive(const TriangleSetup &setup);
-	void draw_shaded_primitive(const TriangleSetup &setup, const AttributeSetup &attr);
+	// setup may be mutated to apply various fixups to triangle setup.
+	void draw_flat_primitive(TriangleSetup &setup);
+	void draw_shaded_primitive(TriangleSetup &setup, const AttributeSetup &attr);
 
 	void set_color_framebuffer(uint32_t addr, uint32_t width, FBFormat fmt);
 	void set_depth_framebuffer(uint32_t addr);
@@ -346,6 +347,7 @@ private:
 	void deduce_static_texture_state(unsigned tile, unsigned max_lod_level);
 	void deduce_noise_state();
 	static StaticRasterizationState normalize_static_state(StaticRasterizationState state);
+	void fixup_triangle_setup(TriangleSetup &setup) const;
 
 	struct Caps
 	{

--- a/parallel-rdp/shaders/binning.h
+++ b/parallel-rdp/shaders/binning.h
@@ -44,6 +44,17 @@ int maximum4(ivec4 v)
 	return max(maximum2.x, maximum2.y);
 }
 
+ivec4 madd_32_64(ivec4 a, int b, int c, out ivec4 hi_bits)
+{
+	ivec4 lo, hi;
+	imulExtended(a, ivec4(b), hi, lo);
+	uvec4 carry;
+	lo = ivec4(uaddCarry(lo, uvec4(c), carry));
+	hi += ivec4(carry);
+	hi_bits = hi;
+	return lo;
+}
+
 ivec2 interpolate_xs(TriangleSetup setup, ivec4 ys, bool flip, int scaling)
 {
 	int yh_interpolation_base = setup.yh & ~(SUBPIXELS_Y - 1);
@@ -52,10 +63,19 @@ ivec2 interpolate_xs(TriangleSetup setup, ivec4 ys, bool flip, int scaling)
 	yh_interpolation_base *= scaling;
 	ym_interpolation_base *= scaling;
 
-	ivec4 xh = scaling * setup.xh + (ys - yh_interpolation_base) * setup.dxhdy;
-	ivec4 xm = scaling * setup.xm + (ys - yh_interpolation_base) * setup.dxmdy;
-	ivec4 xl = scaling * setup.xl + (ys - ym_interpolation_base) * setup.dxldy;
+	// Interpolate in 64-bit so we can detect quirky overflow scenarios.
+	ivec4 xh_hi, xm_hi, xl_hi;
+	ivec4 xh = madd_32_64(ys - yh_interpolation_base, setup.dxhdy, scaling * setup.xh, xh_hi);
+	ivec4 xm = madd_32_64(ys - yh_interpolation_base, setup.dxmdy, scaling * setup.xm, xm_hi);
+	ivec4 xl = madd_32_64(ys - ym_interpolation_base, setup.dxldy, scaling * setup.xl, xl_hi);
 	xl = mix(xl, xm, lessThan(ys, ivec4(scaling * setup.ym)));
+	xl_hi = mix(xl_hi, xm_hi, lessThan(ys, ivec4(scaling * setup.ym)));
+
+	// Handle overflow scenarios. Saturate 64-bit signed to 32-bit signed without 64-bit math.
+	xh = mix(xh, ivec4(0x7fffffff), greaterThan(xh_hi, ivec4(0)));
+	xh = mix(xh, ivec4(-0x80000000), lessThan(xh_hi, ivec4(-1)));
+	xl = mix(xl, ivec4(0x7fffffff), greaterThan(xl_hi, ivec4(0)));
+	xl = mix(xl, ivec4(-0x80000000), lessThan(xl_hi, ivec4(-1)));
 
 	ivec4 xh_shifted = quantize_x(xh);
 	ivec4 xl_shifted = quantize_x(xl);
@@ -72,28 +92,37 @@ ivec2 interpolate_xs(TriangleSetup setup, ivec4 ys, bool flip, int scaling)
 		xright = xh_shifted;
 	}
 
-	return ivec2(minimum4(xleft), maximum4(xright));
+	// If one of the results are out of range, we have overflow, and we need to be conservative when binning.
+	int max_range = maximum4(max(abs(xleft), abs(xright)));
+	ivec2 range;
+	if (max_range <= 2047 * scaling)
+		range = ivec2(minimum4(xleft), maximum4(xright));
+	else
+		range = ivec2(0, 0x7fffffff);
+
+	return range;
 }
 
 bool bin_primitive(TriangleSetup setup, ivec2 lo, ivec2 hi, int scaling)
 {
-    int start_y = lo.y * SUBPIXELS_Y;
-    int end_y = (hi.y * SUBPIXELS_Y) + (SUBPIXELS_Y - 1);
+	int start_y = lo.y * SUBPIXELS_Y;
+	int end_y = (hi.y * SUBPIXELS_Y) + (SUBPIXELS_Y - 1);
 
-    // First, we clip start/end against y_lo, y_hi.
-    start_y = max(start_y, scaling * int(setup.yh));
-    end_y = min(end_y, scaling * int(setup.yl) - 1);
+	// First, we clip start/end against y_lo, y_hi.
+	start_y = max(start_y, scaling * int(setup.yh));
+	end_y = min(end_y, scaling * int(setup.yl) - 1);
 
-    // Y is clipped out, exit early.
-    if (end_y < start_y)
-        return false;
+	// Y is clipped out, exit early.
+	if (end_y < start_y)
+		return false;
 
-    bool flip = (setup.flags & TRIANGLE_SETUP_FLIP_BIT) != 0;
+	bool flip = (setup.flags & TRIANGLE_SETUP_FLIP_BIT) != 0;
 
-    // Sample the X ranges for min and max Y, and potentially the mid-point as well.
-    ivec4 ys = ivec4(start_y, end_y, clamp(setup.ym * scaling + ivec2(-1, 0), ivec2(start_y), ivec2(end_y)));
-    ivec2 x_range = interpolate_xs(setup, ys, flip, scaling);
-    x_range.x = max(x_range.x, lo.x);
+	// Sample the X ranges for min and max Y, and potentially the mid-point as well.
+	ivec4 ys = ivec4(start_y, end_y, clamp(setup.ym * scaling + ivec2(-1, 0), ivec2(start_y), ivec2(end_y)));
+	ivec2 x_range = interpolate_xs(setup, ys, flip, scaling);
+
+	x_range.x = max(x_range.x, lo.x);
 	x_range.y = min(x_range.y, hi.x);
 	return x_range.x <= x_range.y;
 }

--- a/parallel-rdp/shaders/span_setup.comp
+++ b/parallel-rdp/shaders/span_setup.comp
@@ -169,6 +169,13 @@ void main()
     ivec4 xl = setup.xl * SCALING_FACTOR + (y_subs - ym_interpolation_base) * setup.dxldy;
     xl = mix(xl, xm, lessThan(y_subs, ivec4(SCALING_FACTOR * setup.ym)));
 
+    // If we have overflows, we can become sensitive to this in invalid_line check, where
+    // checks that should pass fail, and vice versa.
+    // Note that we shaved off one bit in triangle setup for upscaling purposes,
+    // so this should be 28 bits normally.
+    xl = bitfieldExtract(xl, 0, 27 + SCALING_LOG2);
+    xh = bitfieldExtract(xh, 0, 27 + SCALING_LOG2);
+
     ivec4 xh_shifted = quantize_x(xh);
     ivec4 xl_shifted = quantize_x(xl);
 

--- a/rdp_command_builder.cpp
+++ b/rdp_command_builder.cpp
@@ -46,6 +46,21 @@ unsigned CommandBuilder::draw_triangle(const InputPrimitive &prim)
 	return count;
 }
 
+unsigned CommandBuilder::draw_triangle_ym_out_of_range(const InputPrimitive &prim, int ym_delta)
+{
+	PrimitiveSetup prims[8];
+	unsigned count = setup_clipped_triangles(prims, prim, CullMode::None, viewport);
+	for (unsigned i = 0; i < count; i++)
+	{
+		if (ym_delta < 0)
+			prims[i].pos.y_mid = prims[i].pos.y_lo + ym_delta;
+		else if (ym_delta > 0)
+			prims[i].pos.y_hi = prims[i].pos.y_hi + ym_delta;
+		submit_clipped_primitive(prims[i]);
+	}
+	return count;
+}
+
 void CommandBuilder::end_frame()
 {
 	// Set some known working register state from a dump. No idea what all the bits do yet.

--- a/rdp_command_builder.hpp
+++ b/rdp_command_builder.hpp
@@ -33,6 +33,8 @@ class CommandBuilder : public CommandInterface
 public:
 	void set_viewport(const ViewportTransform &viewport);
 	unsigned draw_triangle(const InputPrimitive &prim);
+	// Tests edge cases when YM is out of range.
+	unsigned draw_triangle_ym_out_of_range(const InputPrimitive &prim, int ym_delta);
 	void fill_rectangle(uint16_t x, uint16_t y, uint16_t width, uint16_t height);
 	void fill_rectangle_subpixels(uint16_t x, uint16_t y, uint16_t width, uint16_t height);
 	void set_scissor(uint16_t x, uint16_t y, uint16_t width, uint16_t height, bool interlace = false, bool keepodd = false);


### PR DESCRIPTION
Fixes two edge cases that content never hits (to my knowledge), but can be triggered in specially written tests.

- Fixes edge case where YM < YH & ~3. We need to explicitly ignore YM here. We do this by setting YM to INT16_MAX.
- Fixes overflows in X range when rasterizing spans. We need to explicitly sign-extend here (at least that's what it seems like you need to do, but AL span setup is extremely cryptic.
- Handling potential overflows is difficult in a binner, so we detect this with 64-bit integer math and treat any overflows as a bin-pass. This can potentially lower performance for this kind of content, but then again, no known "real" content hits this case, we just need it to work.