### PR TITLE
Load block does not transfer anything if too many texels are requested.

### DIFF
--- a/parallel-rdp/rdp_renderer.cpp
+++ b/parallel-rdp/rdp_renderer.cpp
@@ -3112,7 +3112,7 @@ void Renderer::load_tile(uint32_t tile, const LoadTileInfo &info)
 	else
 	{
 		unsigned pixel_count = ((info.shi - info.slo) + 1) & 0xfff;
-		if (!pixel_count)
+		if (!pixel_count || pixel_count > 2048)
 			return;
 	}
 


### PR DESCRIPTION
Verified on hardware.