### PR TITLE
Fix noise when used in second cycle

### DIFF
--- a/parallel-rdp/rdp_renderer.cpp
+++ b/parallel-rdp/rdp_renderer.cpp
@@ -1148,7 +1148,7 @@ void Renderer::deduce_noise_state()
 		if (state.combiner[0].rgb.muladd == RGBMulAdd::Noise)
 			state.flags |= RASTERIZATION_NEED_NOISE_BIT;
 	}
-	else if (state.combiner[1].rgb.muladd == RGBMulAdd::Noise)
+	if (state.combiner[1].rgb.muladd == RGBMulAdd::Noise)
 		state.flags |= RASTERIZATION_NEED_NOISE_BIT;
 
 	if ((state.flags & (RASTERIZATION_ALPHA_TEST_BIT | RASTERIZATION_ALPHA_TEST_DITHER_BIT)) ==


### PR DESCRIPTION
The condition chain didn't catch the case in which RDP is in 2-cyc mode and the noise is used in the second cycle.